### PR TITLE
Relaxing scss_lint version

### DIFF
--- a/pronto-scss.gemspec
+++ b/pronto-scss.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'scss_lint', '~> 0.39.0'
+  s.add_runtime_dependency 'scss_lint', '~> 0.39'
   s.add_runtime_dependency 'pronto', '~> 0.4.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
It'd be better if we could pick later versions of scss_lint without waiting for this gem to be updated. IMHO we can assume it will work.
