### PR TITLE
Update scss_lint gem version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+before_install:
+  - gem update bundler
 language: ruby
 rvm:
-- 1.9.3
-- 2.0.0
-- 2.1
-- 2.2
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2

--- a/lib/pronto/scss.rb
+++ b/lib/pronto/scss.rb
@@ -12,7 +12,11 @@ module Pronto
       files = scss_patches.map(&:new_file_full_path)
 
       if files.any?
-        runner.run(SCSSLint::FileFinder.new(config).find(files))
+        files_hash =
+          SCSSLint::FileFinder.new(config).find(files).map do |path|
+            { path: path }
+          end
+        runner.run(files_hash)
         messages_for(scss_patches)
       else
         []

--- a/pronto-scss.gemspec
+++ b/pronto-scss.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency('scss_lint', '~> 0.42.0')
+  s.add_runtime_dependency('scss_lint', '~> 0.43.0')
   s.add_runtime_dependency('pronto', '~> 0.5.0')
   s.add_development_dependency('rake', '~> 10.4')
   s.add_development_dependency('rspec', '~> 3.3')


### PR DESCRIPTION
Now [scss-lint](https://github.com/brigade/scss-lint) latest version is `0.43.2`.

So let's update `pronto-scss` together!

I fixed the parameter for `SCSSLint::Runner#run`.

And I would like to use this patch on my app, as next `pronto-scss` version :)
